### PR TITLE
Interpolate errors correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Harmonium was originally conceived as a set of styled React components ([harmoni
 
 Here are a just few of the features:
 
-* Flexible grid layout system
-* Enhanced form helpers that decorate your inputs with errors and help text in a uniform way
-* Functions for inserting just the right CSS class names, for those moments when you want to go off the pre-built path
+- Flexible grid layout system
+- Enhanced form helpers that decorate your inputs with errors and help text in a uniform way
+- Functions for inserting just the right CSS class names, for those moments when you want to go off the pre-built path
 
 ## Installation
 
@@ -27,6 +27,13 @@ def deps do
 end
 ```
 
+Then, in `config.exs`, pass in your Phoenix application's error translator function:
+
+```
+config :harmonium,
+  error_helper: &YourAppWeb.ErrorHelpers.translate_error/1
+```
+
 From your app's root directory, run this command to get the `harmonium` package from NPM, which contains the SCSS you'll need:
 
 ```bash
@@ -34,6 +41,7 @@ $(cd assets && npm install --save harmonium)
 ```
 
 In `assets/app.scss`, import the SCSS:
+
 ```scss
 @import '~harmonium/scss/app';
 ```
@@ -41,6 +49,7 @@ In `assets/app.scss`, import the SCSS:
 For more details, and a set of Starter Settings for configuring Harmonium styles, go to [harmonium.revelry.co](https://harmonium.revelry.co/)
 
 ## Example Usage
+
 ```elixir
 <%= form_for @changeset, @action, fn f -> %>
   <%= row do %>

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -22,6 +22,9 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :harmonium,
+  error_helper: &ExampleWeb.ErrorHelpers.translate_error/1
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -228,16 +228,15 @@ defmodule Harmonium do
     end
   end
 
-  # Gets the error helper function from Phoenix config
+  # Get the error helper function from the host application
+  # for translating and interpolating error messages.
+  #
+  # Returns the text of the error message if the helper isn't configured.
   defp error_helper(error) do
     case Application.get_env(:harmonium, :error_helper, nil) do
       nil ->
-        raise """
-          No error helper configured for Harmonium. Please add the following config to your Phoenix application:
-
-          config :harmonium,
-            error_helper: &YourAppWeb.ErrorHelpers.translate_error/1
-        """
+        {message, opts} = error
+        message
 
       error_helper ->
         error_helper.(error)

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -327,9 +327,14 @@ defmodule Harmonium do
       "<label class=\\\"rev-InputLabel rev-InputStack \\\">  \\n  <input class=\\\"rev-Input \\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" placeholder=\\\"Required String\\\" type=\\\"text\\\" value=\\\"hello\\\">\\n  \\n  \\n</label>"
 
   When the field has an error, error styles are applied, and it is displayed.
-
+      iex> Application.put_env(:harmonium, :error_helper, nil)
       iex> text_input_stack(form_with_errors, :required_string) |> safe_to_string()
       "<label class=\\\"rev-InputLabel rev-InputStack is-invalid\\\">  \\n  <input class=\\\"rev-Input is-invalid\\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" type=\\\"text\\\">\\n  <small class=\\\"rev-InputErrors\\\">can&#39;t be blank</small>\\n  \\n</label>"
+
+  If an error helper from the host application is configured, it is used to format errors.
+      iex> Application.put_env(:harmonium, :error_helper, &mock_translate_error/1)
+      iex> text_input_stack(form_with_errors, :required_string) |> safe_to_string()
+      "<label class=\\\"rev-InputLabel rev-InputStack is-invalid\\\">  \\n  <input class=\\\"rev-Input is-invalid\\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" type=\\\"text\\\">\\n  <small class=\\\"rev-InputErrors\\\">This is a translated or formatted error</small>\\n  \\n</label>"
   """
   def text_input_stack(f, key, options \\ []) do
     input_stack(&text_input/3, @input_class, @input_stack_class, f, key, options)

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Harmonium.MixProject do
   def project do
     [
       app: :harmonium,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/harmonium_test.exs
+++ b/test/harmonium_test.exs
@@ -46,5 +46,9 @@ defmodule HarmoniumTest do
     changeset_with_errors() |> to_form()
   end
 
+  def mock_translate_error(_) do
+    "This is a translated or formatted error"
+  end
+
   doctest Harmonium
 end


### PR DESCRIPTION
connects to #10 

- add a config option to pass in an error helper from the host project to interpolate/translate errors properly
- if config isn't present, fall back to the original behavior of returning the plain text error message