### PR TITLE
Update Elixir and maybe fix Travis auto-publish on tags functionality

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.7.4
+erlang 21.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.6
+  - 1.7
 otp_release:
-  - 20.2
+  - 21.1
 cache:
   directories:
     - _build
@@ -26,12 +26,6 @@ deploy:
   provider: script
   # http://yaml.org/spec/1.2/spec.html#id2779048
   # `>-` indicates the line folding.
-  script: >-
-    mix deps.get &&
-    mix hex.config username "$HEX_USERNAME" &&
-    (mix hex.config encrypted_key "$HEX_ENCRYPTED_KEY" > /dev/null 2>&1) &&
-    (echo "$HEX_PASSPHRASE" | mix hex.publish --no-confirm) &&
-    mix clean &&
-    mix deps.clean --all
+  script: mix hex.publish --yes
   on:
     tags: true

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Harmonium.MixProject do
     [
       app: :harmonium,
       version: "2.0.1",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
- bump Elixir version and add `.tool-versions` file for greater precision
- update Travis deploy script to use new Hex capabilities (https://hex.pm/blog/hex-v0.18-released#improvements-to-continuous-integration-workflows)

It still needs a couple of things to finish setting up Travis:
1. run `mix hex.user key generate` locally
2. set that value as `HEX_API_KEY` in Travis