### PR TITLE
Take a {Module, :function} tuple for the :error_helper config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Phoenix Framework view helpers for Harmonium-styled HTML without React.
 
-Harmonium was originally conceived as a set of styled React components ([harmonium.revelry.co](https://harmonium.revelry.co/)). This library brings the style and markup framework of Harmonium into Phoenix, but leaves the JavaScript behind. 
+Harmonium was originally conceived as a set of styled React components ([harmonium.revelry.co](https://harmonium.revelry.co/)). This library brings the style and markup framework of Harmonium into Phoenix, but leaves the JavaScript behind.
 
 Here are a just few of the features:
 
@@ -31,7 +31,7 @@ Then, in `config.exs`, pass in your Phoenix application's error translator funct
 
 ```
 config :harmonium,
-  error_helper: &YourAppWeb.ErrorHelpers.translate_error/1
+  error_helper: {YourAppWeb.ErrorHelpers, :translate_error}
 ```
 
 From your app's root directory, run this command to get the `harmonium` package from NPM, which contains the SCSS you'll need:

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -23,7 +23,7 @@ config :logger, :console,
 config :phoenix, :json_library, Jason
 
 config :harmonium,
-  error_helper: &ExampleWeb.ErrorHelpers.translate_error/1
+  error_helper: {ExampleWeb.ErrorHelpers, :translate_error}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -238,6 +238,12 @@ defmodule Harmonium do
         {message, opts} = error
         message
 
+      {module, function} -> apply(module, function, [error])
+
+      # this version was intended to take a function capture
+      # like `MyAppWeb.ErrorHelpers.translate_error/1`,
+      # but the tuple version is now preferred because
+      # function captures aren't supported in releases
       error_helper ->
         error_helper.(error)
     end
@@ -331,7 +337,12 @@ defmodule Harmonium do
       iex> text_input_stack(form_with_errors, :required_string) |> safe_to_string()
       "<label class=\\\"rev-InputLabel rev-InputStack is-invalid\\\">  \\n  <input class=\\\"rev-Input is-invalid\\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" type=\\\"text\\\">\\n  <small class=\\\"rev-InputErrors\\\">can&#39;t be blank</small>\\n  \\n</label>"
 
-  If an error helper from the host application is configured, it is used to format errors.
+  If an error helper from the host application is configured, it is used to format errors. (TUPLE FORMAT)
+      iex> Application.put_env(:harmonium, :error_helper, {HarmoniumTest, :mock_translate_error})
+      iex> text_input_stack(form_with_errors, :required_string) |> safe_to_string()
+      "<label class=\\\"rev-InputLabel rev-InputStack is-invalid\\\">  \\n  <input class=\\\"rev-Input is-invalid\\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" type=\\\"text\\\">\\n  <small class=\\\"rev-InputErrors\\\">This is a translated or formatted error</small>\\n  \\n</label>"
+
+  If an error helper from the host application is configured, it is used to format errors. (DEPRECATED FUNCTION CAPTURE FORMAT)
       iex> Application.put_env(:harmonium, :error_helper, &mock_translate_error/1)
       iex> text_input_stack(form_with_errors, :required_string) |> safe_to_string()
       "<label class=\\\"rev-InputLabel rev-InputStack is-invalid\\\">  \\n  <input class=\\\"rev-Input is-invalid\\\" id=\\\"widget_required_string\\\" name=\\\"widget[required_string]\\\" type=\\\"text\\\">\\n  <small class=\\\"rev-InputErrors\\\">This is a translated or formatted error</small>\\n  \\n</label>"

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -243,7 +243,7 @@ defmodule Harmonium do
       # this version was intended to take a function capture
       # like `MyAppWeb.ErrorHelpers.translate_error/1`,
       # but the tuple version is now preferred because
-      # function captures aren't supported in releases
+      # function captures in config.exs break the release process
       error_helper ->
         error_helper.(error)
     end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Connects to #86 

The existing behavior has been preserved, but documentation has been updated to show the new method, and deprecation comments have been added to the old case and corresponding doctest.