### PR TITLE
Version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `harmonium` to your list of dependencies in `mix.exs` before running `mix de
 ```elixir
 def deps do
   [
-    {:harmonium, "~> 1.0.0"}
+    {:harmonium, "~> 2.1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Harmonium.MixProject do
   def project do
     [
       app: :harmonium,
-      version: "2.0.1",
+      version: "2.1.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
There are projects that would benefit from having [this feature](https://github.com/revelrylabs/phoenix_harmonium/pull/87) in the wild now that we're using releases, so I think it's time for a new version. I bumped minor b/c it's a change in the public API, but the old usage is still supported as well.

The thing I don't understand is when to create the release tag so that travis does the deploy on the merged commit but not on the PR itself... so I haven't done anything there. If I get a good answer maybe I'll update the README to be slightly clearer for folks who don't have experience with this kind of release.

I did create a [draft release](https://github.com/revelrylabs/phoenix_harmonium/releases/tag/untagged-b04b6df6b35fe40cce55)