### PR TITLE
WIP: Input groups

### DIFF
--- a/example/assets/css/app.scss
+++ b/example/assets/css/app.scss
@@ -1,1 +1,34 @@
 @import '~harmonium/scss/app';
+
+
+/**
+* The input_group_field helper produces slightly different markup
+* from the React component FieldGroup.Field. These styles can be
+* used to make the appropriate adjustments
+*/
+.rev-InputGroup-fieldWrapper{
+  width: 100%;
+
+  input, select, textarea {
+    @include input-style;
+    border-radius: 0;
+    &:first-child {
+      border-bottom-left-radius: $input-radius;
+      border-top-left-radius: $input-radius;
+    }
+    &:last-child {
+      border-bottom-right-radius: $input-radius;
+      border-top-right-radius: $input-radius;
+    }
+  }
+
+  input {
+    @extend .rev-Input;
+  }
+  select {
+    @extend .rev-Select;
+  }
+  textarea {
+    @extend .rev-Textarea;
+  }
+}

--- a/example/lib/example_web/templates/page/index.html.eex
+++ b/example/lib/example_web/templates/page/index.html.eex
@@ -167,40 +167,54 @@ airports = [{"Louis Armstrong", "MSY"}, {"John F. Kennedy", "JFK"}]
 
         <%= row do %>
           <%= col do %>
-            <h4><strong>Input Groups (no helpers yet)</strong></h4>
-          <% end %>
-
-          <%= col do %>
-            <label class="rev-InputLabel">
-              <span class="rev-LabelText">Input Group</span>
-              <div class="rev-InputGroup">
-                <select class="rev-Select rev-InputGroup-field">
-                  <option>1</option>
-                  <option>2</option>
-                  <option>3</option>
-                </select>
-                <input class="rev-Input rev-InputGroup-field" placeholder="Placeholder"/>
-                <div class="rev-InputGroup-button">
-                  <button class="rev-Button">Button</button>
-                </div>
-              </div>
-              <small class="rev-InputHelpText rev-HelpText">Help text goes here</small>
-            </label>
-          <% end %>
-
-          <%= col do %>
-            <div class="rev-InputGroup">
-              <span class="rev-InputGroup-label Prefix">$</span>
-              <input type="number" class="rev-InputGroup-field rev-Input" value="100">
-              <div class="rev-InputGroup-button">
-                <button class="rev-Button rev-Button--secondary">Cancel</button>
-              </div>
-              <div class="rev-InputGroup-button">
-                <button class="rev-Button">Save</button>
-              </div>
-            </div>
+            <h4><strong>Input Groups</strong></h4>
+            <p>
+              <strong>Note:</strong> There are slight differences in the <code>input_group_field</code> markup.
+              Find supplemental styles for <code>rev-InputGroup-fieldWrapper</code> in app.scss.
+            </p>
           <% end %>
         <% end %>
+
+        <%= row do %>
+          <%= col do %>
+            <%= input_group_stack f, :airport, label: "Input Group Stack", help: "Help text goes here" do %>
+              <%= input_group_field do %>
+                <%= select f, :airport, airports %>
+              <% end %>
+              <%= input_group_field do %>
+                <%= text_input f, :something, placeholder: "Placeholder" %>
+              <% end %>
+              <%= input_group_button do %>
+                <button class="rev-Button">Button</button>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= row do %>
+          <%= col do %>
+            <p>
+              Standalone input group w/o stack
+            </p>
+          <% end %>
+        <% end %>
+        <%= row do %>
+          <%= col do %>
+            <%= input_group do %>
+              <%= input_group_label class: "Prefix" do %>$<% end %>
+              <%= input_group_field do %>
+                <%= text_input f, :int, type: :number %>
+              <% end %>
+              <%= input_group_button do %>
+                <button class="rev-Button rev-Button--secondary">Cancel</button>
+              <% end %>
+              <%= input_group_button do %>
+                <button class="rev-Button">Save</button>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <%# end input groups %>
 
         <%= row do %>
           <%= col do %>

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -6,6 +6,7 @@ defmodule Harmonium do
   import Phoenix.HTML
   import Phoenix.HTML.Form
   import Phoenix.HTML.Tag
+  alias Harmonium.InputGroup
 
   @row_class "rev-Row"
   @col_class "rev-Col"
@@ -35,6 +36,17 @@ defmodule Harmonium do
   @drawer_expander_class "#{@drawer_class}-expander"
   @drawer_contents_class "#{@drawer_class}-contents"
   @icon_class "rev-Icon"
+
+  defdelegate input_group(block), to: InputGroup
+  defdelegate input_group(modifiers, block), to: InputGroup
+  defdelegate input_group_label(block), to: InputGroup
+  defdelegate input_group_label(modifiers, block), to: InputGroup
+  defdelegate input_group_field(block), to: InputGroup
+  defdelegate input_group_field(modifiers, block), to: InputGroup
+  defdelegate input_group_button(block), to: InputGroup
+  defdelegate input_group_button(modifiers, block), to: InputGroup
+  defdelegate input_group_stack(f, key, block), to: InputGroup
+  defdelegate input_group_stack(f, key, modifiers, block), to: InputGroup
 
   @doc """
   Constructs a CSS class with SUIT modifiers.
@@ -262,7 +274,7 @@ defmodule Harmonium do
   # See `text_input_stack/3` and `select_stack/4` for example usage.
   # For other, less uniform input types, you may have to write something more custom.
   # In those cases, this function's code can still be a good reference example.
-  defp input_stack(func, input_class, stack_class, f, key, options, value_options \\ nil) do
+  def input_stack(func, input_class, stack_class, f, key, options, value_options \\ nil) do
     error = extract_error(f, key)
 
     validity_class = if error, do: @invalid_class, else: ""

--- a/lib/harmonium/input_group.ex
+++ b/lib/harmonium/input_group.ex
@@ -1,0 +1,74 @@
+defmodule Harmonium.InputGroup do
+  @moduledoc """
+  The InputGroup is a grouping on several related labels, inputs, and buttons
+  together in a compact format. For example, you can group an input, along
+  with a relevant caption or unit of measure, along with several buttons
+  to take action on that input.
+  """
+  # import Phoenix.HTML
+  # import Phoenix.HTML.Form
+  import Phoenix.HTML.Tag
+
+  @input_group_class "rev-InputGroup"
+  @input_group_stack_class "rev-InputGroupStack"
+
+  def input_group_class(modifiers \\ []) do
+    Harmonium.rev_class(@input_group_class, modifiers)
+  end
+
+  def element_class(element, modifiers \\ []) do
+    Harmonium.rev_class("#{@input_group_class}-#{element}", modifiers)
+  end
+
+  def input_group(do: block), do: input_group([], do: block)
+
+  def input_group(modifiers, do: block) do
+    content_tag :div, class: input_group_class(modifiers) do
+      block
+    end
+  end
+
+  def input_group_label(do: block), do: input_group_label([], do: block)
+
+  def input_group_label(modifiers, do: block) do
+    content_tag :span, class: element_class("label", modifiers) do
+      block
+    end
+  end
+
+  def input_group_field(do: block), do: input_group_field([], do: block)
+
+  @doc """
+  NOTE: in Harmonium, the InputGroup.Field doesn't have any markup of its own.
+  Instead it decorates its children with the `rev-InputGroup-field` class
+  This is not a thing we can do in Phoenix, but we _can_ create some new CSS that
+  applies those styles by targeting the `fieldWrapper` class and child elements
+  See app.scss
+  """
+  def input_group_field(modifiers, do: block) do
+    content_tag :div, class: element_class("fieldWrapper", modifiers) do
+      block
+    end
+  end
+
+  def input_group_button(do: block), do: input_group_button([], do: block)
+
+  def input_group_button(modifiers, do: block) do
+    content_tag :div, class: element_class("button", modifiers) do
+      block
+    end
+  end
+
+  def input_group_stack(f, key, do: block), do: input_group_stack(f, key, [], do: block)
+
+  @doc """
+    NOTE: The stack will only display errors attached to the key provided here,
+    regardless of how many different inputs are in the group.
+  """
+  def input_group_stack(f, key, options, do: block) do
+    render = fn _, _, options ->
+      input_group(options, [do: block])
+    end
+    Harmonium.input_stack(render, "", @input_group_stack_class, f, key, options)
+  end
+end


### PR DESCRIPTION
Connects to #42 

Two things I still need to work out:
- There aren't any tests yet. I'd like to avoid doing doctests that aren't human-readable (a la #49), and I also need to generally figure out the setup situation
- I wasn't able to produce markup that's identical to the React components, because the `InputStack.Field` actually modifies its children rather than rendering a wrapper around them. This can be overcome with some additional CSS (which I've taken a stab at), but I'm not totally sure about the best way to make this user-friendly now... ?

<details>
<summary>Screenshots</summary>

Before (bottom) and after (top)

<img src="https://user-images.githubusercontent.com/802805/64211842-188a8880-ce6d-11e9-9da9-899f92d90638.png">

After only, with a note about the CSS situation

<img src="https://user-images.githubusercontent.com/802805/64211910-496abd80-ce6d-11e9-998c-7707668c27b2.png">

</details>