### PR TITLE
handle 'for' attribute in single checkbox creation

### DIFF
--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -458,12 +458,12 @@ defmodule Harmonium do
   Render a single checkbox.
 
       iex> single_checkbox(f, :bool) |> safe_to_string()
-      "<label class=\\\"rev-InputLabel rev-Checkbox\\\"><input name=\\\"widget[bool]\\\" type=\\\"hidden\\\" value=\\\"false\\\"><input class=\\\"rev-Checkbox-input\\\" id=\\\"widget_bool\\\" name=\\\"widget[bool]\\\" type=\\\"checkbox\\\" value=\\\"true\\\"></label>"
+      "<label class=\\\"rev-InputLabel rev-Checkbox\\\" for=\\\"widget_bool\\\"><input name=\\\"widget[bool]\\\" type=\\\"hidden\\\" value=\\\"false\\\"><input class=\\\"rev-Checkbox-input\\\" id=\\\"widget_bool\\\" name=\\\"widget[bool]\\\" type=\\\"checkbox\\\" value=\\\"true\\\"></label>"
 
   You may optionally add a label:
 
       iex> single_checkbox(f, :bool, label: "Publish?") |> safe_to_string()
-      "<label class=\\\"rev-InputLabel rev-Checkbox\\\"><input name=\\\"widget[bool]\\\" type=\\\"hidden\\\" value=\\\"false\\\"><input class=\\\"rev-Checkbox-input\\\" id=\\\"widget_bool\\\" name=\\\"widget[bool]\\\" type=\\\"checkbox\\\" value=\\\"true\\\"><span class=\\\"rev-Checkbox-label\\\">Publish?</span></label>"
+      "<label class=\\\"rev-InputLabel rev-Checkbox\\\" for=\\\"widget_bool\\\"><input name=\\\"widget[bool]\\\" type=\\\"hidden\\\" value=\\\"false\\\"><input class=\\\"rev-Checkbox-input\\\" id=\\\"widget_bool\\\" name=\\\"widget[bool]\\\" type=\\\"checkbox\\\" value=\\\"true\\\"><span class=\\\"rev-Checkbox-label\\\">Publish?</span></label>"
   """
   def single_checkbox(f, key, options \\ []) do
     input_options =

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -196,14 +196,16 @@ defmodule Harmonium do
   Renders an input label.
   """
   def rev_label(modifiers, do: block) do
+    content_tag :label, class: rev_label_class(modifiers) do
+      block
+    end
+  end
 
-    for_attr = modifiers
-      |> Keyword.get(:for)
-
-    class = modifiers
-      |> Keyword.take(:class)
-
-    content_tag :label, class: rev_label_class(class), for: for_attr do
+  @doc """
+  Renders an input label with a for attribute.
+  """
+  def rev_label(f, key, modifiers, do: block) do
+    label f, key, class: rev_label_class(modifiers) do
       block
     end
   end
@@ -482,13 +484,7 @@ defmodule Harmonium do
           end
       end
 
-      for_attr =
-        case options[:for] do
-            nil -> nil
-            text -> text
-            end
-
-    rev_label class: "rev-Checkbox", for: for_attr do
+    rev_label f, key, class: "rev-Checkbox" do
       ~E"<%= box %><%= label %>"
     end
   end

--- a/lib/harmonium.ex
+++ b/lib/harmonium.ex
@@ -196,7 +196,14 @@ defmodule Harmonium do
   Renders an input label.
   """
   def rev_label(modifiers, do: block) do
-    content_tag :label, class: rev_label_class(modifiers) do
+
+    for_attr = modifiers
+      |> Keyword.get(:for)
+
+    class = modifiers
+      |> Keyword.take(:class)
+
+    content_tag :label, class: rev_label_class(class), for: for_attr do
       block
     end
   end
@@ -475,7 +482,13 @@ defmodule Harmonium do
           end
       end
 
-    rev_label class: "rev-Checkbox" do
+      for_attr =
+        case options[:for] do
+            nil -> nil
+            text -> text
+            end
+
+    rev_label class: "rev-Checkbox", for: for_attr do
       ~E"<%= box %><%= label %>"
     end
   end


### PR DESCRIPTION
@jwietelmann: @oohnoitz and I were working through a minor issue due to the fact we don't handle "for" attributes in phoenix-harmonium. This fix works for our issue, but I'm sure there are other considerations I can't foresee here. Curious for your thoughts/concerns around the approach, or if you think it's worth doing at all. 
